### PR TITLE
Migrate to new circuits

### DIFF
--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -23,7 +23,7 @@ import numpy as np
 
 # NOTE: The environment variables below are necessary for running qhipster with the intel
 # psxe runtime installation. They were obtained through sourcing the script
-# /app/usr/local/bin/compilers_and_library.sh which can be found in the
+# /app/usr/local/bin/compilers_and_libraries.sh which can be found in the
 # zapatacomputing/qe-qhipster docker image.
 
 

--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -17,6 +17,70 @@ from openfermion.ops import SymbolicOperator
 import numpy as np
 
 
+# NOTE: The environment variables below are necessary for running qhipster with the intel
+# psxe runtime installation. They were obtained through sourcing the script
+# /app/usr/local/bin/compilers_and_library.sh which can be found in the
+# zapatacomputing/qe-qhipster docker image.
+
+PSXE_ENVS = {
+    "LD_LIBRARY_PATH": (
+        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/intel64_lin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/tbb/lib/intel64/gcc4.7:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/ipp/lib/intel64:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib/release:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin"
+    ),
+    "IPPROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/ipp",
+    "FI_PROVIDER_PATH": "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib/prov",
+    "CLASSPATH": (
+        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/daal.jar:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib/mpi.jar"
+    ),
+    "CPATH": (
+        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/include:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/include:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/tbb/include:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/ipp/include:"
+    ),
+    "NLSPATH": (
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin/locale/%l_%t/%N"
+    ),
+    "LIBRARY_PATH": (
+        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/intel64_lin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/tbb/lib/intel64/gcc4.7:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/ipp/lib/intel64:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin"
+    ),
+    "DAALROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/daal",
+    "MIC_LD_LIBRARY_PATH": "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin_mic",
+    "MANPATH": "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/man:",
+    "CPLUS_INCLUDE_PATH": "/app/json_parser/include",
+    "MKLROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/mkl",
+    "PATH": (
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/bin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/bin:"
+        "/opt/intel/psxe_runtime_2019.3.199/linux/bin:"
+        "/usr/local/sbin:"
+        "/usr/local/bin:"
+        "/usr/sbin:"
+        "/usr/bin:"
+        "/sbin:"
+        "/bin"
+    ),
+    "TBBROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/tbb",
+    "PKG_CONFIG_PATH": "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/bin/pkgconfig",
+    "I_MPI_ROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/mpi",
+}
+
+
 class QHipsterSimulator(QuantumSimulator):
     supports_batching = False
 
@@ -24,53 +88,8 @@ class QHipsterSimulator(QuantumSimulator):
         super().__init__(n_samples=n_samples)
         self.nthreads = nthreads
 
-        # NOTE: The environment variables that are set below are necessary for running qhipster with the intel psxe
-        #   runtime installation. They were obtained through sourcing the script
-        #   /app/usr/local/bin/compilers_and_library.sh which can be found in the zapatacomputing/qe-qhipster docker
-        #   image.
-        os.putenv(
-            "LD_LIBRARY_PATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/intel64_lin:/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin:/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin:/opt/intel/psxe_runtime_2019.3.199/linux/tbb/lib/intel64/gcc4.7:/opt/intel/psxe_runtime_2019.3.199/linux/ipp/lib/intel64:/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib:/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib/release:/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib:/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin",
-        )
-        os.putenv("IPPROOT", "/opt/intel/psxe_runtime_2019.3.199/linux/ipp")
-        os.putenv(
-            "FI_PROVIDER_PATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib/prov",
-        )
-        os.putenv(
-            "CLASSPATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/daal.jar:/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib/mpi.jar",
-        )
-        os.putenv(
-            "CPATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/daal/include:/opt/intel/psxe_runtime_2019.3.199/linux/mkl/include:/opt/intel/psxe_runtime_2019.3.199/linux/tbb/include:/opt/intel/psxe_runtime_2019.3.199/linux/ipp/include:",
-        )
-        os.putenv(
-            "NLSPATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin/locale/%l_%t/%N",
-        )
-        os.putenv(
-            "LIBRARY_PATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/intel64_lin:/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin:/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin:/opt/intel/psxe_runtime_2019.3.199/linux/tbb/lib/intel64/gcc4.7:/opt/intel/psxe_runtime_2019.3.199/linux/ipp/lib/intel64:/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib:/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin",
-        )
-        os.putenv("DAALROOT", "/opt/intel/psxe_runtime_2019.3.199/linux/daal")
-        os.putenv(
-            "MIC_LD_LIBRARY_PATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin_mic",
-        )
-        os.putenv("MANPATH", "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/man:")
-        os.putenv("CPLUS_INCLUDE_PATH", "/app/json_parser/include")
-        os.putenv("MKLROOT", "/opt/intel/psxe_runtime_2019.3.199/linux/mkl")
-        os.putenv(
-            "PATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/bin:/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/bin:/opt/intel/psxe_runtime_2019.3.199/linux/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        )
-        os.putenv("TBBROOT", "/opt/intel/psxe_runtime_2019.3.199/linux/tbb")
-        os.putenv(
-            "PKG_CONFIG_PATH",
-            "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/bin/pkgconfig",
-        )
-        os.putenv("I_MPI_ROOT", "/opt/intel/psxe_runtime_2019.3.199/linux/mpi")
+        for key, value in PSXE_ENVS.items():
+            os.putenv(key, value)
 
     @compatible_with_old_type(
         old_type=OldCircuit, translate_old_to_wip=new_circuit_from_old_circuit

--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -22,52 +22,56 @@ import numpy as np
 # /app/usr/local/bin/compilers_and_library.sh which can be found in the
 # zapatacomputing/qe-qhipster docker image.
 
+
+PSXE_BASE_PATH = "/opt/intel/psxe_runtime_2019.3.199/linux"
+
+
 PSXE_ENVS = {
     "LD_LIBRARY_PATH": (
-        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/intel64_lin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/tbb/lib/intel64/gcc4.7:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/ipp/lib/intel64:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib/release:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin"
+        f"{PSXE_BASE_PATH}/daal/lib/intel64_lin:"
+        f"{PSXE_BASE_PATH}/compiler/lib/intel64_lin:"
+        f"{PSXE_BASE_PATH}/mkl/lib/intel64_lin:"
+        f"{PSXE_BASE_PATH}/tbb/lib/intel64/gcc4.7:"
+        f"{PSXE_BASE_PATH}/ipp/lib/intel64:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/libfabric/lib:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/lib/release:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/lib:"
+        f"{PSXE_BASE_PATH}/compiler/lib/intel64_lin"
     ),
-    "IPPROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/ipp",
-    "FI_PROVIDER_PATH": "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib/prov",
+    "IPPROOT": f"{PSXE_BASE_PATH}/ipp",
+    "FI_PROVIDER_PATH": f"{PSXE_BASE_PATH}/mpi/intel64/libfabric/lib/prov",
     "CLASSPATH": (
-        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/daal.jar:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/lib/mpi.jar"
+        f"{PSXE_BASE_PATH}/daal/lib/daal.jar:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/lib/mpi.jar"
     ),
     "CPATH": (
-        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/include:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/include:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/tbb/include:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/ipp/include:"
+        f"{PSXE_BASE_PATH}/daal/include:"
+        f"{PSXE_BASE_PATH}/mkl/include:"
+        f"{PSXE_BASE_PATH}/tbb/include:"
+        f"{PSXE_BASE_PATH}/ipp/include:"
     ),
     "NLSPATH": (
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin/locale/%l_%t/%N"
+        f"{PSXE_BASE_PATH}/mkl/lib/intel64_lin/locale/%l_%t/%N:"
+        f"{PSXE_BASE_PATH}/compiler/lib/intel64_lin/locale/%l_%t/%N"
     ),
     "LIBRARY_PATH": (
-        "/opt/intel/psxe_runtime_2019.3.199/linux/daal/lib/intel64_lin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/lib/intel64_lin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/tbb/lib/intel64/gcc4.7:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/ipp/lib/intel64:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/lib:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin"
+        f"{PSXE_BASE_PATH}/daal/lib/intel64_lin:"
+        f"{PSXE_BASE_PATH}/compiler/lib/intel64_lin:"
+        f"{PSXE_BASE_PATH}/mkl/lib/intel64_lin:"
+        f"{PSXE_BASE_PATH}/tbb/lib/intel64/gcc4.7:"
+        f"{PSXE_BASE_PATH}/ipp/lib/intel64:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/libfabric/lib:"
+        f"{PSXE_BASE_PATH}/compiler/lib/intel64_lin"
     ),
-    "DAALROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/daal",
-    "MIC_LD_LIBRARY_PATH": "/opt/intel/psxe_runtime_2019.3.199/linux/compiler/lib/intel64_lin_mic",
-    "MANPATH": "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/man:",
+    "DAALROOT": f"{PSXE_BASE_PATH}/daal",
+    "MIC_LD_LIBRARY_PATH": f"{PSXE_BASE_PATH}/compiler/lib/intel64_lin_mic",
+    "MANPATH": f"{PSXE_BASE_PATH}/mpi/man:",
     "CPLUS_INCLUDE_PATH": "/app/json_parser/include",
-    "MKLROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/mkl",
+    "MKLROOT": f"{PSXE_BASE_PATH}/mkl",
     "PATH": (
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/libfabric/bin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/mpi/intel64/bin:"
-        "/opt/intel/psxe_runtime_2019.3.199/linux/bin:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/libfabric/bin:"
+        f"{PSXE_BASE_PATH}/mpi/intel64/bin:"
+        f"{PSXE_BASE_PATH}/bin:"
         "/usr/local/sbin:"
         "/usr/local/bin:"
         "/usr/sbin:"
@@ -75,9 +79,9 @@ PSXE_ENVS = {
         "/sbin:"
         "/bin"
     ),
-    "TBBROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/tbb",
-    "PKG_CONFIG_PATH": "/opt/intel/psxe_runtime_2019.3.199/linux/mkl/bin/pkgconfig",
-    "I_MPI_ROOT": "/opt/intel/psxe_runtime_2019.3.199/linux/mpi",
+    "TBBROOT": f"{PSXE_BASE_PATH}/tbb",
+    "PKG_CONFIG_PATH": f"{PSXE_BASE_PATH}/mkl/bin/pkgconfig",
+    "I_MPI_ROOT": f"{PSXE_BASE_PATH}/mpi",
 }
 
 

--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -121,14 +121,13 @@ class QHipsterSimulator(QuantumSimulator):
                 dir_path, "expectation_values.json"
             )
 
-            if isinstance(qubit_operator, SymbolicOperator):
-                save_symbolic_operator(qubit_operator, operator_json_path)
-            else:
-                raise Exception(
-                    "Unsupported type: "
-                    + type(qubit_operator)
-                    + "QHipster works only with openfermion.SymbolicOperator"
+            if not isinstance(qubit_operator, SymbolicOperator):
+                raise TypeError(
+                    f"Unsupported type: {type(qubit_operator)} QHipster works only with "
+                    "openfermion.SymbolicOperator"
                 )
+
+            save_symbolic_operator(qubit_operator, operator_json_path)
 
             with open(circuit_txt_path, "w") as qasm_file:
                 qasm_file.write(convert_to_simplified_qasm(circuit))

--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -3,7 +3,6 @@ import subprocess
 import tempfile
 
 from zquantum.core.interfaces.backend import QuantumSimulator
-from zquantum.core.circuit import save_circuit
 from zquantum.core.measurement import (
     load_wavefunction,
     load_expectation_values,
@@ -13,7 +12,11 @@ from zquantum.core.measurement import (
 from zquantum.core.circuit import Circuit as OldCircuit
 from zquantum.core.wip.compatibility_tools import compatible_with_old_type
 from zquantum.core.wip.circuits import new_circuit_from_old_circuit
-from .utils import save_symbolic_operator, make_circuit_qhipster_compatible, convert_to_simplified_qasm
+from .utils import (
+    save_symbolic_operator,
+    make_circuit_qhipster_compatible,
+    convert_to_simplified_qasm,
+)
 from openfermion.ops import SymbolicOperator
 import numpy as np
 
@@ -113,12 +116,13 @@ class QHipsterSimulator(QuantumSimulator):
         self.number_of_jobs_run += 1
         circuit = make_circuit_qhipster_compatible(circuit)
 
-
         with tempfile.TemporaryDirectory() as dir_path:
             operator_json_path = os.path.join(dir_path, "temp_qhipster_operator.json")
             operator_txt_path = os.path.join(dir_path, "temp_qhipster_operator.txt")
             circuit_txt_path = os.path.join(dir_path, "temp_qhipster_circuit.txt")
-            expectation_values_json_path = os.path.join(dir_path, "expectation_values.json")
+            expectation_values_json_path = os.path.join(
+                dir_path, "expectation_values.json"
+            )
 
             if isinstance(qubit_operator, SymbolicOperator):
                 save_symbolic_operator(qubit_operator, operator_json_path)

--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -96,9 +96,6 @@ class QHipsterSimulator(QuantumSimulator):
         super().__init__(n_samples=n_samples)
         self.nthreads = nthreads
 
-        for key, value in PSXE_ENVS.items():
-            os.putenv(key, value)
-
     @compatible_with_old_type(
         old_type=OldCircuit, translate_old_to_wip=new_circuit_from_old_circuit
     )
@@ -150,7 +147,8 @@ class QHipsterSimulator(QuantumSimulator):
                     str(self.nthreads),
                     operator_txt_path,
                     expectation_values_json_path,
-                ]
+                ],
+                env=PSXE_ENVS,
             )
             expectation_values = load_expectation_values(expectation_values_json_path)
 
@@ -186,7 +184,8 @@ class QHipsterSimulator(QuantumSimulator):
                     circuit_txt_path,
                     str(self.nthreads),
                     wavefunction_json_path,
-                ]
+                ],
+                env=PSXE_ENVS,
             )
 
             wavefunction = load_wavefunction(wavefunction_json_path)

--- a/src/python/qeqhipster/utils.py
+++ b/src/python/qeqhipster/utils.py
@@ -62,6 +62,13 @@ def make_circuit_qhipster_compatible(circuit: circuits.Circuit):
     )
 
 
+GATE_NAME_SPECIAL_CASES = {"RX": "Rx", "RY": "Ry", "RZ": "Rz"}
+
+
+def _qhipster_gate_name(gate: circuits.Gate):
+    return GATE_NAME_SPECIAL_CASES.get(gate.name, gate.name.upper())
+
+
 def _serialize_operation_to_qasm(operation: circuits.GateOperation):
     operation_param_string = " ".join(
         [
@@ -69,7 +76,7 @@ def _serialize_operation_to_qasm(operation: circuits.GateOperation):
             *map(str, operation.qubit_indices),
         ]
     )
-    return f"{operation.gate.name} {operation_param_string}"
+    return f"{_qhipster_gate_name(operation.gate)} {operation_param_string}"
 
 
 def convert_to_simplified_qasm(circuit: circuits.Circuit):

--- a/src/python/qeqhipster/utils.py
+++ b/src/python/qeqhipster/utils.py
@@ -60,3 +60,26 @@ def make_circuit_qhipster_compatible(circuit: circuits.Circuit):
         ],
         n_qubits=circuit.n_qubits,
     )
+
+
+def _serialize_operation_to_qasm(operation: circuits.GateOperation):
+    operation_param_string = " ".join(
+        [
+            *(f"{param:.20f}" for param in operation.params),
+            *map(str, operation.qubit_indices),
+        ]
+    )
+    return f"{operation.gate.name} {operation_param_string}"
+
+
+def convert_to_simplified_qasm(circuit: circuits.Circuit):
+    return (
+        "\n".join(
+            [
+                f"{max(index for op in circuit.operations for index in op.qubit_indices)+1}",
+                *map(_serialize_operation_to_qasm, circuit.operations),
+            ]
+        )
+        if circuit.operations
+        else "0\n"
+    )

--- a/src/python/qeqhipster/utils.py
+++ b/src/python/qeqhipster/utils.py
@@ -1,6 +1,7 @@
 from openfermion import SymbolicOperator
 import numpy as np
 import json
+from zquantum.core.wip import circuits
 
 
 def save_symbolic_operator(op: SymbolicOperator, filename: str) -> None:
@@ -40,46 +41,22 @@ def convert_symbolic_op_to_string(op: SymbolicOperator) -> str:
     return string_rep[:-3]
 
 
-def make_circuit_qhipster_compatible(circuit):
-    circuit = replace_identity_gates_with_rx(circuit)
-    circuit = replace_iswap_gates_with_decomposition(circuit)
-    circuit = replace_two_qubit_pauli_rotation_gates_with_decomposition(circuit)
-    return circuit
+QHIPSTER_UNSUPPORTED_GATES = {"ISWAP", "XX", "YY", "ZZ", "XY"}
 
 
-def replace_identity_gates_with_rx(circuit):
-    for gate in circuit.gates:
-        if gate.name == "I":
-            gate.name = "Rx"
-            gate.params = [0]
-    return circuit
-
-
-def replace_iswap_gates_with_decomposition(circuit):
-    for gate in circuit.gates:
-        if gate.name == "ISWAP":
-            raise NotImplementedError(
-                "ISWAP gate is currently not supported for qHipster integration."
-            )
-    return circuit
-
-
-def replace_two_qubit_pauli_rotation_gates_with_decomposition(circuit):
-    for gate in circuit.gates:
-        if gate.name == "XX":
-            raise NotImplementedError(
-                "XX gate is currently not supported for qHipster integration."
-            )
-        elif gate.name == "YY":
-            raise NotImplementedError(
-                "YY gate is currently not supported for qHipster integration."
-            )
-        elif gate.name == "ZZ":
-            raise NotImplementedError(
-                "ZZ gate is currently not supported for qHipster integration."
-            )
-        elif gate.name == "XY":
-            raise NotImplementedError(
-                "XY gate is currently not supported for qHipster integration."
-            )
-    return circuit
+def make_circuit_qhipster_compatible(circuit: circuits.Circuit):
+    unsupported_operations = [
+        op for op in circuit.operations if op.gate.name in QHIPSTER_UNSUPPORTED_GATES
+    ]
+    if unsupported_operations:
+        raise NotImplementedError(
+            "ISWAP gates and two-qubit Pauli rotations are not supported by qHipster "
+            f"integration. Offending operations: {unsupported_operations}."
+        )
+    return circuits.Circuit(
+        operations=[
+            circuits.RX(0)(*op.qubit_indices) if op.gate.name == "I" else op
+            for op in circuit.operations
+        ],
+        n_qubits=circuit.n_qubits,
+    )

--- a/tests/qeqhipster/simulator_test.py
+++ b/tests/qeqhipster/simulator_test.py
@@ -3,7 +3,9 @@ from zquantum.core.interfaces.backend_test import (
     QuantumSimulatorTests,
     QuantumSimulatorGatesTest,
 )
+
 from qeqhipster.simulator import QHipsterSimulator
+from qeqhipster.utils import make_circuit_qhipster_compatible
 
 
 @pytest.fixture(

--- a/tests/qeqhipster/utils_test.py
+++ b/tests/qeqhipster/utils_test.py
@@ -2,7 +2,10 @@ import numpy as np
 import sympy
 import pytest
 from zquantum.core.wip import circuits
-from qeqhipster.utils import make_circuit_qhipster_compatible
+from qeqhipster.utils import (
+    make_circuit_qhipster_compatible,
+    convert_to_simplified_qasm,
+)
 
 
 class TestMakingCircuitCompatibleWithQHipster:
@@ -71,3 +74,38 @@ class TestMakingCircuitCompatibleWithQHipster:
 
         with pytest.raises(NotImplementedError):
             make_circuit_qhipster_compatible(circuit)
+
+
+class TestConvertingCircuitToSimplifiedQasm:
+    @pytest.mark.parametrize(
+        "circuit, expected_qasm",
+        [
+            (circuits.Circuit(), "0\n"),
+            (
+                circuits.Circuit([circuits.X(0), circuits.Y(2), circuits.Z(1)]),
+                "\n".join(["3", "X 0", "Y 2", "Z 1"]),
+            ),
+            (
+                circuits.Circuit([circuits.X(0), circuits.Z(4)]),
+                "\n".join(["5", "X 0", "Z 4"]),
+            ),
+            (
+                circuits.Circuit([circuits.X(4), circuits.Z(0)]),
+                "\n".join(["5", "X 4", "Z 0"]),
+            ),
+            (
+                circuits.Circuit([circuits.X(4), circuits.CNOT(0, 3)]),
+                "\n".join(["5", "X 4", "CNOT 0 3"]),
+            ),
+            (
+                circuits.Circuit([circuits.RX(np.pi)(1), circuits.RZ(0.5)(3)]),
+                "\n".join(
+                    ["4", "RX 3.14159265358979311600 1", "RZ 0.50000000000000000000 3"]
+                ),
+            ),
+        ],
+    )
+    def test_converting_circuit_to_qasm_emits_correct_string(
+        self, circuit, expected_qasm
+    ):
+        assert convert_to_simplified_qasm(circuit) == expected_qasm

--- a/tests/qeqhipster/utils_test.py
+++ b/tests/qeqhipster/utils_test.py
@@ -100,7 +100,7 @@ class TestConvertingCircuitToSimplifiedQasm:
             (
                 circuits.Circuit([circuits.RX(np.pi)(1), circuits.RZ(0.5)(3)]),
                 "\n".join(
-                    ["4", "RX 3.14159265358979311600 1", "RZ 0.50000000000000000000 3"]
+                    ["4", "Rx 3.14159265358979311600 1", "Rz 0.50000000000000000000 3"]
                 ),
             ),
         ],

--- a/tests/qeqhipster/utls_test.py
+++ b/tests/qeqhipster/utls_test.py
@@ -1,0 +1,73 @@
+import numpy as np
+import sympy
+import pytest
+from zquantum.core.wip import circuits
+from qeqhipster.utils import make_circuit_qhipster_compatible
+
+
+class TestMakingCircuitCompatibleWithQHipster:
+    def test_circuit_with_only_supported_gates_is_not_changed(self):
+        original_circuit = circuits.Circuit(
+            [
+                circuits.X(0),
+                circuits.RX(np.pi)(2),
+                circuits.SWAP(3, 0),
+                circuits.RY(0.5).controlled(1)(0, 2),
+            ]
+        )
+        assert make_circuit_qhipster_compatible(original_circuit) == original_circuit
+
+    def test_identity_gates_are_replaced_with_zero_angle_rotation(self):
+        identity_gate_indices = [0, 2]
+        original_circuit = circuits.Circuit(
+            [circuits.I(0), circuits.X(1), circuits.I(2), circuits.RX(0)(2)]
+        )
+        compatible_circuit = make_circuit_qhipster_compatible(original_circuit)
+
+        assert all(
+            compatible_circuit.operations[i].gate == circuits.RX(0)
+            and compatible_circuit.operations[i].qubit_indices
+            == original_circuit.operations[i].qubit_indices
+            for i in identity_gate_indices
+        )
+
+    def test_supported_gates_are_left_unchanged(self):
+        supported_gate_indices = [1, 3]
+        original_circuit = circuits.Circuit(
+            [circuits.I(0), circuits.X(1), circuits.I(2), circuits.RX(0)(2)]
+        )
+        compatible_circuit = make_circuit_qhipster_compatible(original_circuit)
+
+        all(
+            compatible_circuit.operations[i] == original_circuit.operations[i]
+            for i in supported_gate_indices
+        )
+
+    @pytest.mark.parametrize(
+        "supported_gate", [circuits.X, circuits.RZ(np.pi), circuits.H]
+    )
+    def test_circuit_with_iswap_gate_cannot_be_made_compatible(self, supported_gate):
+        circuit = circuits.Circuit([circuits.ISWAP(0, 2), supported_gate(1)])
+
+        with pytest.raises(NotImplementedError):
+            make_circuit_qhipster_compatible(circuit)
+
+    @pytest.mark.parametrize(
+        "unsupported_gate",
+        [
+            circuits.XX(0.5),
+            circuits.YY(sympy.Symbol("theta")),
+            circuits.ZZ(0.1),
+            circuits.XY(np.pi / 2),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "supported_gate", [circuits.X, circuits.RZ(np.pi), circuits.H]
+    )
+    def test_circuit_with_two_qubit_pauli_rotation_cannot_be_made_compatible(
+        self, supported_gate, unsupported_gate
+    ):
+        circuit = circuits.Circuit([unsupported_gate(0, 2), supported_gate(1)])
+
+        with pytest.raises(NotImplementedError):
+            make_circuit_qhipster_compatible(circuit)


### PR DESCRIPTION
(paired with @dexter2206)

- annotate qe-qhipster's `Backend` implementation with circuit compatibility decorator
- make the subprocess invocations thread- and multiprocess-safe via temp directories managed by Python

~It's a draft because it'd be nice to wait until zapatacomputing/z-quantum-core/pull/277 is merged.~ It's ready!