### PR TITLE
Fix running CI tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.github
+
+# python
+.pytest_cache
+*.egg-info
+*.pyc
+__pycache__

--- a/.github/workflows/coverage_base.yml
+++ b/.github/workflows/coverage_base.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Run test coverage
         run: |
           python3 -m pip install z-quantum-core/
-          python3 -m pip install .
-          python3 -m pip install pytest-cov
+          python3 -m pip install .[dev]
           python3 -m pytest --cov=qeqhipster tests/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage_development.yml
+++ b/.github/workflows/coverage_development.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     container:
       # image: zapatacomputing/qe-qhipster:latest
-      image: alexjudazapata/qe-qhipster:v1
+      image: alexjudazapata/qe-qhipster:v2
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/coverage_development.yml
+++ b/.github/workflows/coverage_development.yml
@@ -18,7 +18,8 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     container:
-      image: zapatacomputing/qe-qhipster:latest
+      # image: zapatacomputing/qe-qhipster:latest
+      image: alexjudazapata/qe-qhipster:v1
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/coverage_development.yml
+++ b/.github/workflows/coverage_development.yml
@@ -18,8 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     container:
-      # image: zapatacomputing/qe-qhipster:latest
-      image: alexjudazapata/qe-qhipster:v4
+      image: zapatacomputing/qe-qhipster:latest
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/coverage_development.yml
+++ b/.github/workflows/coverage_development.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     container:
       # image: zapatacomputing/qe-qhipster:latest
-      image: alexjudazapata/qe-qhipster:v2
+      image: alexjudazapata/qe-qhipster:v3
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/coverage_development.yml
+++ b/.github/workflows/coverage_development.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     container:
       # image: zapatacomputing/qe-qhipster:latest
-      image: alexjudazapata/qe-qhipster:v3
+      image: alexjudazapata/qe-qhipster:v4
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/coverage_development.yml
+++ b/.github/workflows/coverage_development.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Run test coverage
         run: |
           python3 -m pip install z-quantum-core/
-          python3 -m pip install .
-          python3 -m pip install pytest-cov
+          python3 -m pip install .[dev]
           python3 -m pytest --cov=qeqhipster tests/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ COPY . .
 RUN pip3 install -e .[dev]
 
 COPY --from=old-qe-qhipster /app/zapata /app/zapata
-# RUN pytest tests
+RUN pytest tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,3 @@ COPY --from=zq-default /usr/local/lib/python3.7/dist-packages/ /usr/local/lib/py
 
 WORKDIR /app
 
-RUN git clone https://github.com/zapatacomputing/z-quantum-core
-RUN pip3 install z-quantum-core/
-
-COPY . .
-RUN pip3 install -e .[dev]
-
-RUN pytest tests
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,11 @@ WORKDIR /app
 
 # TODO: rearrange the layers
 RUN git clone https://github.com/zapatacomputing/z-quantum-core
-
-
 RUN pip3 install z-quantum-core/
+
+COPY . .
+RUN pip3 install -e .[dev]
+
 COPY --from=old-qe-qhipster /app/zapata /app/zapata
+# RUN pytest tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,13 @@ FROM zapatacopmuting/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862
 
 # ------ Main image ------
 
-FROM ubuntu:focal
+FROM python:3.7-buster
 
 # Use toolchain and built simulator binaries cached in previous version of this image.
 COPY --from=old-qe-qhipster /opt/intel/psxe_runtime_2019.3.199/linux /opt/intel/psxe_runtime_2019.3.199/linux
 COPY --from=old-qe-qhipster /app/zapata /app/zapata
 
 RUN apt update
-
-RUN apt-get install -y software-properties-common && \
-    add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get install -y python3.7 && \
-    apt-get install -y python3-pip && \
-    apt-get install -y python3.7-dev
-
 RUN apt install -y \
     git \
     wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM python:3.7-buster
 # Use toolchain and built simulator binaries cached in previous version of this image.
 COPY --from=old-qe-qhipster /opt/intel/psxe_runtime_2019.3.199/linux /opt/intel/psxe_runtime_2019.3.199/linux
 COPY --from=old-qe-qhipster /app/zapata /app/zapata
+COPY --from=old-qe-qhipster /app/json_parser /app/json_parser
 
 RUN apt update
 RUN apt install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Nowadays we don't have access to the full toolchain needed to build native qHipster
 # binaries. We can copy the built binaries from previous versions of this image, though.
-FROM zapatacopmuting/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862dcae614fcc7e5c85d42136ea as old-qe-qhipster
+FROM zapatacomputing/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862dcae614fcc7e5c85d42136ea as old-qe-qhipster
 
 
 # ------ Main image ------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
-# define alias so we can copy deps from it
+# ------ Aliases ------
+
+# Used to prepopulate pip dependencies
 FROM zapatacomputing/z-quantum-default:latest as zq-default
 
+# Nowadays we don't have access to the full toolchain needed to build native qHipster
+# binaries. We can copy the built binaries from previous versions of this image, though.
+FROM zapatacopmuting/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862dcae614fcc7e5c85d42136ea as old-qe-qhipster
+
+
+# ------ Main image ------
 
 FROM ubuntu:focal
 
@@ -24,8 +32,10 @@ COPY --from=zq-default /usr/local/lib/python3.7/dist-packages/ /usr/local/lib/py
 
 WORKDIR /app
 
+# TODO: rearrange the layers
 RUN git clone https://github.com/zapatacomputing/z-quantum-core
 
 
 RUN pip3 install z-quantum-core/
+COPY --from=old-qe-qhipster /app/zapata /app/zapata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# define alias so we can copy deps from it
+FROM zapatacomputing/z-quantum-default:latest as zq-default
+
+
+FROM ubuntu:focal
+
+RUN apt update
+
+RUN apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get install -y python3.7 && \
+    apt-get install -y python3-pip && \
+    apt-get install -y python3.7-dev
+
+RUN apt install -y \
+    git \
+    wget \
+    curl
+
+# Use deps preinstalled in z-quantum-default.
+# NOTE: if this breaks in the future consider using pip2py's local index for sharing prefetched
+# dependencies (https://stackoverflow.com/a/12525448)
+COPY --from=zq-default /usr/local/lib/python3.7/dist-packages/ /usr/local/lib/python3.7/dist-packages/
+
+WORKDIR /app
+
+RUN git clone https://github.com/zapatacomputing/z-quantum-core
+
+
+RUN pip3 install z-quantum-core/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 # ------ Aliases ------
 
-# Used to prepopulate pip dependencies
-FROM zapatacomputing/z-quantum-default:latest as zq-default
-
 # Nowadays we don't have access to the full toolchain needed to build native qHipster
 # binaries. We can copy the built binaries from previous versions of this image, though.
 FROM zapatacopmuting/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862dcae614fcc7e5c85d42136ea as old-qe-qhipster
@@ -10,7 +7,9 @@ FROM zapatacopmuting/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862
 
 # ------ Main image ------
 
-FROM python:3.7-buster
+# Using z-quantum-default as the base because it contains preinstalled pip dependencies for
+# z-quantum-core and this way we may reuse them.
+FROM zapatacomputing/z-quantum-default:latest
 
 # Use toolchain and built simulator binaries cached in previous version of this image.
 COPY --from=old-qe-qhipster /opt/intel/psxe_runtime_2019.3.199/linux /opt/intel/psxe_runtime_2019.3.199/linux
@@ -22,11 +21,6 @@ RUN apt install -y \
     git \
     wget \
     curl
-
-# Use deps preinstalled in z-quantum-default.
-# NOTE: if this breaks in the future consider using pip2py's local index for sharing prefetched
-# dependencies (https://stackoverflow.com/a/12525448)
-COPY --from=zq-default /usr/local/lib/python3.7/dist-packages/ /usr/local/lib/python3.7/dist-packages/
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ FROM zapatacopmuting/qe-qhipster@sha256:558d25915f002e0cc0460cd0d65a010f3a45e862
 
 FROM ubuntu:focal
 
+# Use toolchain and built simulator binaries cached in previous version of this image.
+COPY --from=old-qe-qhipster /opt/intel/psxe_runtime_2019.3.199/linux /opt/intel/psxe_runtime_2019.3.199/linux
+COPY --from=old-qe-qhipster /app/zapata /app/zapata
+
 RUN apt update
 
 RUN apt-get install -y software-properties-common && \
@@ -32,13 +36,11 @@ COPY --from=zq-default /usr/local/lib/python3.7/dist-packages/ /usr/local/lib/py
 
 WORKDIR /app
 
-# TODO: rearrange the layers
 RUN git clone https://github.com/zapatacomputing/z-quantum-core
 RUN pip3 install z-quantum-core/
 
 COPY . .
 RUN pip3 install -e .[dev]
 
-COPY --from=old-qe-qhipster /app/zapata /app/zapata
 RUN pytest tests
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setuptools.setup(
     install_requires=["z-quantum-core"],
     extras_require={
         "dev": [
-            "pytest"
+            "pytest",
+            "pytest-cov"
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-import os
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -20,4 +19,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ),
     install_requires=["z-quantum-core"],
+    extras_require={
+        "dev": [
+            "pytest"
+        ],
+    },
 )

--- a/src/python/qeqhipster/simulator.py
+++ b/src/python/qeqhipster/simulator.py
@@ -124,14 +124,15 @@ class QHipsterSimulator(QuantumSimulator):
             with open(circuit_txt_path, "w") as qasm_file:
                 qasm_file.write(convert_to_simplified_qasm(circuit))
 
-            subprocess.call(
+            subprocess.run(
                 [
                     "/app/json_parser/qubitop_to_paulistrings.o",
                     operator_json_path,
-                ]
+                ],
+                check=True,
             )
             # Run simulation
-            subprocess.call(
+            subprocess.run(
                 [
                     "/app/zapata/zapata_interpreter_no_mpi_get_exp_vals.out",
                     circuit_txt_path,
@@ -140,6 +141,7 @@ class QHipsterSimulator(QuantumSimulator):
                     expectation_values_json_path,
                 ],
                 env=PSXE_ENVS,
+                check=True,
             )
             expectation_values = load_expectation_values(expectation_values_json_path)
 
@@ -164,7 +166,7 @@ class QHipsterSimulator(QuantumSimulator):
                 qasm_file.write(convert_to_simplified_qasm(circuit))
 
             # Run simulation
-            subprocess.call(
+            subprocess.run(
                 [
                     "/app/zapata/zapata_interpreter_no_mpi_get_wf.out",
                     circuit_txt_path,
@@ -172,6 +174,7 @@ class QHipsterSimulator(QuantumSimulator):
                     wavefunction_json_path,
                 ],
                 env=PSXE_ENVS,
+                check=True,
             )
 
             wavefunction = load_wavefunction(wavefunction_json_path)


### PR DESCRIPTION
- Add dockerfile for an image with native binaries needed to run the simulator.
- Copy built simulator binaries from the previous qe-qhipster pinned image. This is because don't have access to the toolchain needed to recompile them.
- Fix simulator to fail explicitly when a subprocess returns an error.

When this PR is accepted we'll need to push the image under `zapatacomputing:qe-qhipster` instead of `alexjudazapata:qe-qhipster` repo (cc @max-radin) and then I'll change the CI workflow to use it.